### PR TITLE
Fix decoder fallbacks.

### DIFF
--- a/src/AuthenticodeLint.Core/Asn/AsnBmpString.cs
+++ b/src/AuthenticodeLint.Core/Asn/AsnBmpString.cs
@@ -25,7 +25,7 @@ namespace AuthenticodeLint.Core.Asn
             {
                 ElementData = elementData.ConstrainWith(contentData, contentLength.Value);
                 ContentData = contentData.Constrain(contentLength.Value);
-                Value = Encoding.BigEndianUnicode.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
+                Value = AsnTextEncoding.BigEndianUnicode.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
             }
             catch (Exception e) when (e is ArgumentException || e is DecoderFallbackException)
             {

--- a/src/AuthenticodeLint.Core/Asn/AsnIA5String.cs
+++ b/src/AuthenticodeLint.Core/Asn/AsnIA5String.cs
@@ -24,7 +24,7 @@ namespace AuthenticodeLint.Core.Asn
             {
                 ElementData = elementData.ConstrainWith(contentData, contentLength.Value);
                 ContentData = contentData.Constrain(contentLength.Value);
-                Value = Encoding.ASCII.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
+                Value = AsnTextEncoding.ASCII.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
             }
             catch (Exception e) when (e is ArgumentException || e is DecoderFallbackException)
             {

--- a/src/AuthenticodeLint.Core/Asn/AsnPrintableString.cs
+++ b/src/AuthenticodeLint.Core/Asn/AsnPrintableString.cs
@@ -24,7 +24,7 @@ namespace AuthenticodeLint.Core.Asn
             {
                 ElementData = elementData.ConstrainWith(contentData, contentLength.Value);
                 ContentData = contentData.Constrain(contentLength.Value);
-                Value = Encoding.ASCII.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
+                Value = AsnTextEncoding.ASCII.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
             }
             catch (Exception e) when (e is ArgumentException || e is DecoderFallbackException)
             {

--- a/src/AuthenticodeLint.Core/Asn/AsnTextEncoding.cs
+++ b/src/AuthenticodeLint.Core/Asn/AsnTextEncoding.cs
@@ -1,0 +1,25 @@
+using System.Text;
+
+namespace AuthenticodeLint.Core.Asn
+{
+    internal static class AsnTextEncoding
+    {
+        public static Encoding ASCII { get; } = Encoding.GetEncoding(
+            Encoding.ASCII.CodePage,
+            new EncoderExceptionFallback(),
+            new DecoderExceptionFallback()
+        );
+
+        public static Encoding UTF8 { get; } = Encoding.GetEncoding(
+            Encoding.UTF8.CodePage,
+            new EncoderExceptionFallback(),
+            new DecoderExceptionFallback()
+        );
+
+        public static Encoding BigEndianUnicode { get; } = Encoding.GetEncoding(
+            Encoding.BigEndianUnicode.CodePage,
+            new EncoderExceptionFallback(),
+            new DecoderExceptionFallback()
+        );
+    }
+}

--- a/src/AuthenticodeLint.Core/Asn/AsnUtf8String.cs
+++ b/src/AuthenticodeLint.Core/Asn/AsnUtf8String.cs
@@ -37,7 +37,7 @@ namespace AuthenticodeLint.Core.Asn
             {
                 ElementData = elementData.ConstrainWith(contentData, contentLength.Value);
                 ContentData = contentData.Constrain(contentLength.Value);
-                Value = Encoding.UTF8.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
+                Value = AsnTextEncoding.UTF8.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
             }
             catch (Exception e) when (e is ArgumentException || e is DecoderFallbackException)
             {

--- a/src/AuthenticodeLint.Core/Asn/AsnVisibleString.cs
+++ b/src/AuthenticodeLint.Core/Asn/AsnVisibleString.cs
@@ -9,13 +9,6 @@ namespace AuthenticodeLint.Core.Asn
         public override ArraySegment<byte> ContentData { get; }
         public override ArraySegment<byte> ElementData { get; }
 
-        private static Encoding Decoder { get; }
-
-        static AsnVisibleString()
-        {
-            Decoder = Encoding.GetEncoding(Encoding.ASCII.CodePage, new EncoderExceptionFallback(), new DecoderExceptionFallback());
-        }
-
         public AsnVisibleString(AsnTag tag, ArraySegment<byte> contentData, ArraySegment<byte> elementData, ulong? contentLength)
             : base(tag)
         {
@@ -31,7 +24,7 @@ namespace AuthenticodeLint.Core.Asn
             {
                 ElementData = elementData.ConstrainWith(contentData, contentLength.Value);
                 ContentData = contentData.Constrain(contentLength.Value);
-                Value = Decoder.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
+                Value = AsnTextEncoding.ASCII.GetString(ContentData.Array, ContentData.Offset, ContentData.Count);
             }
             catch (Exception e) when (e is ArgumentException || e is DecoderFallbackException)
             {

--- a/tests/AuthenticodeLint.Core.Tests/AsnBmpStringTests.cs
+++ b/tests/AuthenticodeLint.Core.Tests/AsnBmpStringTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using AuthenticodeLint.Core.Asn;
 using Xunit;
 
@@ -16,6 +17,18 @@ namespace AuthenticodeLint.Core.Tests
             var decoded = AsnDecoder.Decode(data);
             var bmpString = Assert.IsType<AsnBmpString>(decoded);
             Assert.Equal("hello", bmpString.Value);
+        }
+
+        [Fact]
+        public void ShouldThrowExceptionWithInvalidUnicodeSequence()
+        {
+            var data = new byte[] {
+                0x1E, //asn.1 bmp string
+                0x02, //with a length of two
+                0xD8, 0x00 //bad surrogate
+            };
+            var exception = Assert.Throws<AsnException>(() => AsnDecoder.Decode(data));
+            Assert.IsType<DecoderFallbackException>(exception.InnerException);
         }
     }
 }

--- a/tests/AuthenticodeLint.Core.Tests/AsnDecoderTests.cs
+++ b/tests/AuthenticodeLint.Core.Tests/AsnDecoderTests.cs
@@ -58,20 +58,6 @@ namespace AuthenticodeLint.Core.Tests
             Assert.Equal(expected, SerializeArraySegement(octetString.Value));
         }
 
-        [Fact]
-        public void ShouldDecodeIA5String()
-        {
-            var data = new byte[]
-            {
-                0x16, //IA5String tag
-                0x05, //with a content length of 5
-                0x68, 0x65, 0x6c, 0x6c, 0x6f //ascii "hello"
-            };
-            var decoded = AsnDecoder.Decode(data);
-            var ia5String = Assert.IsType<AsnIA5String>(decoded);
-            Assert.Equal("hello", ia5String.Value);
-        }
-
         private static T[] SerializeArraySegement<T>(ArraySegment<T> segement)
         {
             var arr = new T[segement.Count];

--- a/tests/AuthenticodeLint.Core.Tests/AsnIA5StringTests.cs
+++ b/tests/AuthenticodeLint.Core.Tests/AsnIA5StringTests.cs
@@ -1,0 +1,50 @@
+using System.Text;
+using AuthenticodeLint.Core.Asn;
+using Xunit;
+
+namespace AuthenticodeLint.Core.Tests
+{
+    public class AsnIA5StringTests
+    {
+        [Fact]
+        public void ShouldDecodeIA5String()
+        {
+            var data = new byte[]
+            {
+                0x16, //IA5String tag
+                0x05, //with a content length of 5
+                0x68, 0x65, 0x6c, 0x6c, 0x6f //ascii "hello"
+            };
+            var decoded = AsnDecoder.Decode(data);
+            var ia5String = Assert.IsType<AsnIA5String>(decoded);
+            Assert.Equal("hello", ia5String.Value);
+        }
+
+        [Fact]
+        public void ShouldNotDecodeBeyondSpecifiedTagLength()
+        {
+            var data = new byte[]
+            {
+                0x16, //IA5String tag
+                0x05, //with a content length of 5
+                0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x6f, 0x6f, 0x6f, 0x6f //ascii "helloooo"
+            };
+            var decoded = AsnDecoder.Decode(data);
+            var ia5String = Assert.IsType<AsnIA5String>(decoded);
+            Assert.Equal("hello", ia5String.Value);
+        }
+
+        [Fact]
+        public void ShouldThrowAsnExceptionWithBadData()
+        {
+            var data = new byte[]
+            {
+                0x16, //IA5String tag
+                0x05, //with a content length of 5
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+            };
+            var exception = Assert.Throws<AsnException>(() => AsnDecoder.Decode(data));
+            Assert.IsType<DecoderFallbackException>(exception.InnerException);
+        }
+    }
+}

--- a/tests/AuthenticodeLint.Core.Tests/AsnVisibleStringTests.cs
+++ b/tests/AuthenticodeLint.Core.Tests/AsnVisibleStringTests.cs
@@ -43,7 +43,7 @@ namespace AuthenticodeLint.Core.Tests
                 0x68, 0x65, 0x6c, 0x6F, 0xFF //with a value of "helo?"
             };
             var exception = Assert.Throws<AsnException>(() => AsnDecoder.Decode(data));
-            Assert.IsType<DecoderFallbackException>(exception);
+            Assert.IsType<DecoderFallbackException>(exception.InnerException);
         }
 
         [Fact]

--- a/tests/AuthenticodeLint.Core.Tests/AsnVisibleStringTests.cs
+++ b/tests/AuthenticodeLint.Core.Tests/AsnVisibleStringTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using AuthenticodeLint.Core.Asn;
 using Xunit;
 
@@ -41,7 +42,8 @@ namespace AuthenticodeLint.Core.Tests
                 0x05, //with a length of 5
                 0x68, 0x65, 0x6c, 0x6F, 0xFF //with a value of "helo?"
             };
-            var decoded = Assert.Throws<AsnException>(() => AsnDecoder.Decode(data));
+            var exception = Assert.Throws<AsnException>(() => AsnDecoder.Decode(data));
+            Assert.IsType<DecoderFallbackException>(exception);
         }
 
         [Fact]
@@ -55,7 +57,7 @@ namespace AuthenticodeLint.Core.Tests
                 0x68, 0x65, 0x6c, 0x6C, 0x6F, //with a value of "hello"
                 0x00, 0x00 //terminator
             };
-            var decoded = Assert.Throws<AsnException>(() => AsnDecoder.Decode(data));
+            Assert.Throws<AsnException>(() => AsnDecoder.Decode(data));
         }
     }
 }


### PR DESCRIPTION
If the text decoder encountered unknown data, it was silently continuing.
This change throws an exception instead.

Fixes #66.