### PR TITLE
Change how 2 digit years are handled for Windows.

### DIFF
--- a/src/AuthenticodeLint.Core/Asn/AsnUtcTime.cs
+++ b/src/AuthenticodeLint.Core/Asn/AsnUtcTime.cs
@@ -13,7 +13,7 @@ namespace AuthenticodeLint.Core.Asn
         static AsnUtcTime()
         {
             _parsingCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
-            _parsingCulture.DateTimeFormat.Calendar = new UTCTimeCalendar();
+            _parsingCulture.DateTimeFormat.Calendar.TwoDigitYearMax = 2049;
         }
 
         public DateTimeOffset Value { get; }
@@ -55,16 +55,5 @@ namespace AuthenticodeLint.Core.Asn
         }
 
         public override string ToString() => Value.ToString();
-
-
-        //This is dumb trick to get UTCTime to handle two digit years the way the specification says.
-        //UTCTime only supports dates between 1/1/1950 and 12/31/2049 (with GeneralizedTime being the
-        //way to fix that.) If the two digit year is less then fifty, then the year should be interpreted
-        //as in the 2000s. Otherwise, it's the 1900s. This is a specialized calendar that is given to the parser
-        //that follows this rule.
-        private class UTCTimeCalendar : GregorianCalendar
-        {
-            public override int ToFourDigitYear(int year) => (year < 50 ? 2000 : 1900) + year;
-        }
     }
 }


### PR DESCRIPTION
All tests should still pass, this code was failing in Windows.

Fixes #79.